### PR TITLE
respect tags_sort_alphabetically setting

### DIFF
--- a/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
+++ b/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
@@ -8,11 +8,12 @@ module ::DiscoursePresetTopicComposer
       tag_group = params[:tag_group]
       tag_group = CGI.unescape(tag_group)
 
-      if SiteSetting.tags_sort_alphabetically
-        tag_order = "name ASC"
-      else
-        tag_order = "public_topic_count DESC"
-      end
+      tag_order =
+        if SiteSetting.tags_sort_alphabetically
+          "name ASC"
+        else
+          "public_topic_count DESC"
+        end
 
       tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags&.order(tag_order) || []
       render json: {

--- a/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
+++ b/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
@@ -14,7 +14,7 @@ module ::DiscoursePresetTopicComposer
         tag_order = "public_topic_count DESC"
       end
 
-      tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags.order(tag_order) || []
+      tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags&.order(tag_order) || []
       render json: { tags: tags }
     end
   end

--- a/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
+++ b/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
@@ -7,7 +7,14 @@ module ::DiscoursePresetTopicComposer
     def search_tags_by_tag_group
       tag_group = params[:tag_group]
       tag_group = CGI.unescape(tag_group)
-      tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags || []
+
+      if SiteSetting.tags_sort_alphabetically
+        tag_order = "name ASC"
+      else
+        tag_order = "public_topic_count DESC"
+      end
+
+      tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags.order(tag_order) || []
       render json: { tags: tags }
     end
   end

--- a/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
+++ b/app/controllers/discourse_preset_topic_composer/preset_tag_groups_controller.rb
@@ -15,7 +15,9 @@ module ::DiscoursePresetTopicComposer
       end
 
       tags = TagGroup.visible(guardian).find_by(name: tag_group)&.tags&.order(tag_order) || []
-      render json: { tags: tags }
+      render json: {
+               tags: ActiveModel::ArraySerializer.new(tags, each_serializer: TagSerializer).as_json,
+             }
     end
   end
 end

--- a/spec/system/page_objects/components/preset_composer_input.rb
+++ b/spec/system/page_objects/components/preset_composer_input.rb
@@ -21,6 +21,11 @@ module PageObjects
         input.last.find(".name").text
       end
 
+      def get_first_list_options
+        input.first.click
+        input.first.find(".select-kit-collection").find_all("li")
+      end
+
       def input
         find(".tag-group_wrapper").find_all(".select-kit.combobox.combo-box")
       end

--- a/spec/system/preset_topic_composer_spec.rb
+++ b/spec/system/preset_topic_composer_spec.rb
@@ -232,5 +232,24 @@ RSpec.describe "Preset Topic Composer | preset topic creation", type: :system do
       button = find("li[title='New Question3']")
       expect(button[:class]).to include("is-highlighted")
     end
+
+    it "should sort alphabetically if SiteSetting is enabled" do
+      SiteSetting.tags_sort_alphabetically = true
+      Fabricate(:topic, tags: [tag_synonym_for_tag1])
+      visit "/"
+
+      preset_dropdown = PageObjects::Components::PresetTopicDropdown.new
+      preset_dropdown.select("New Question2")
+      preset_input = PageObjects::Components::PresetComposerInput.new
+      expect(preset_input.get_first_list_options.first.text).to eq(tag1.name)
+
+      SiteSetting.tags_sort_alphabetically = false
+      visit "/"
+      
+      preset_dropdown = PageObjects::Components::PresetTopicDropdown.new
+      preset_dropdown.select("New Question2")
+      preset_input = PageObjects::Components::PresetComposerInput.new
+      expect(preset_input.get_first_list_options.first.text).to eq(tag_synonym_for_tag1.name)
+    end
   end
 end

--- a/spec/system/preset_topic_composer_spec.rb
+++ b/spec/system/preset_topic_composer_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe "Preset Topic Composer | preset topic creation", type: :system do
 
       SiteSetting.tags_sort_alphabetically = false
       visit "/"
-      
+
       preset_dropdown = PageObjects::Components::PresetTopicDropdown.new
       preset_dropdown.select("New Question2")
       preset_input = PageObjects::Components::PresetComposerInput.new


### PR DESCRIPTION
Currently the `/topic_composer/tag_by_tag_group/{tag}.json` feeds are not sorted.

Proposed change allows the sorting tags alphabetically when the `tags_sort_alphabetically` setting is turned on.