### PR TITLE
Moves selected row to top

### DIFF
--- a/assets/javascripts/discourse/services/dropdown-buttons.js
+++ b/assets/javascripts/discourse/services/dropdown-buttons.js
@@ -24,7 +24,7 @@ export default class DropdownButtonsService extends Service {
             this.#shouldHighlightByCategoryID(button.categoryId) ||
             button.highlightUrls.some((url) => this.#shouldHighlightByURL(url))
           ) {
-            button.classNames = "is-highlighted";
+            button.classNames = "is-selected";
           }
           return button;
         })

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -53,3 +53,12 @@ body.category[style*="--category-color"] .new-topic-dropdown .btn {
   text-align: left;
   color: var(--danger);
 }
+
+.new-topic-dropdown.select-kit .select-kit-collection {
+  display: flex;
+  flex-direction: column;
+
+  .select-kit-row.is-selected {
+    order: -1;
+  }
+}

--- a/spec/system/preset_topic_composer_spec.rb
+++ b/spec/system/preset_topic_composer_spec.rb
@@ -214,23 +214,23 @@ RSpec.describe "Preset Topic Composer | preset topic creation", type: :system do
       expect(preset_input.get_first_label).to eq(tag1.name)
     end
 
-    it "should add is-highlighted class to the button when in matching url" do
+    it "should add is-selected class to the button when in matching url" do
       visit "/tag/#{tag1.name}"
       PageObjects::Components::PresetTopicDropdown.new.button.click
 
-      button = find(:css, ".is-highlighted")
+      button = find(:css, ".is-selected")
       expect(button).to have_text("New Question2")
     end
 
-    it "should add is-highlighted class to the button when in categoryId" do
+    it "should add is-selected class to the button when in categoryId" do
       visit "/c/#{cat.slug}"
       PageObjects::Components::PresetTopicDropdown.new.button.click
 
       button = find("li[title='New Question2']")
-      expect(button[:class]).to include("is-highlighted")
+      expect(button[:class]).to include("is-selected")
 
       button = find("li[title='New Question3']")
-      expect(button[:class]).to include("is-highlighted")
+      expect(button[:class]).to include("is-selected")
     end
 
     it "should sort alphabetically if SiteSetting is enabled" do


### PR DESCRIPTION
* Uses `is-selected` classname. It seems like the select-kit uses `is-highlighted` for the hover event
* Moves the selected row to top of the list
* Updates the class name in the tests
