### PR TITLE
FIX: add `createTopicDisabled` check to new topic button

### DIFF
--- a/assets/javascripts/discourse/connectors/after-create-topic-button/new-topic-dropdown.hbs
+++ b/assets/javascripts/discourse/connectors/after-create-topic-button/new-topic-dropdown.hbs
@@ -1,7 +1,3 @@
 {{#if (and currentUser (not createTopicDisabled))}}
-  {{new-topic-dropdown
-    category=category
-    canCreateTopic=canCreateTopic
-    createTopicDisabled=createTopicDisabled
-  }}
+  {{new-topic-dropdown category=category}}
 {{/if}}

--- a/assets/javascripts/discourse/connectors/after-create-topic-button/new-topic-dropdown.hbs
+++ b/assets/javascripts/discourse/connectors/after-create-topic-button/new-topic-dropdown.hbs
@@ -1,3 +1,7 @@
-{{#if currentUser}}
-  {{new-topic-dropdown category=category}}
+{{#if (and currentUser (not createTopicDisabled))}}
+  {{new-topic-dropdown
+    category=category
+    canCreateTopic=canCreateTopic
+    createTopicDisabled=createTopicDisabled
+  }}
 {{/if}}


### PR DESCRIPTION
it now should behave exactly like the new topic button from core