### PR TITLE
Do all string comparisons in lowercase.

### DIFF
--- a/assets/javascripts/discourse/services/dropdown-buttons.js
+++ b/assets/javascripts/discourse/services/dropdown-buttons.js
@@ -21,7 +21,9 @@ export default class DropdownButtonsService extends Service {
       .map((button) => {
         if (
           this.#shouldHighlightByCategoryID(button.categoryId) ||
-          button.highlightUrls.some((url) => this.#shouldHighlightByURL(url.toLowerCase()))
+          button.highlightUrls.some((url) =>
+            this.#shouldHighlightByURL(url.toLowerCase())
+          )
         ) {
           button.classNames = "is-selected";
         }

--- a/assets/javascripts/discourse/services/dropdown-buttons.js
+++ b/assets/javascripts/discourse/services/dropdown-buttons.js
@@ -21,7 +21,7 @@ export default class DropdownButtonsService extends Service {
       .map((button) => {
         if (
           this.#shouldHighlightByCategoryID(button.categoryId) ||
-          button.highlightUrls.some((url) => this.#shouldHighlightByURL(url))
+          button.highlightUrls.some((url) => this.#shouldHighlightByURL(url.toLowerCase()))
         ) {
           button.classNames = "is-selected";
         }
@@ -36,27 +36,27 @@ export default class DropdownButtonsService extends Service {
     // case 4 - url ends with *, e.g. example*, it should match any url starting with "example"
 
     // Do all string comparisons in lowercase.
-    const _url = url.toLowerCase();
-    const _currentURL = this.router.currentURL.toLowerCase();
+    // the "url" is alredy in lowercase, but the currentURL is not.
+    const currentURL = this.router.currentURL.toLowerCase();
 
-    const startsWithStar = _url.startsWith("*");
-    const endsWithStar = _url.endsWith("*");
+    const startsWithStar = url.startsWith("*");
+    const endsWithStar = url.endsWith("*");
     const exactMatch = !startsWithStar && !endsWithStar;
 
     if (exactMatch) {
-      return _url === _currentURL;
+      return url === currentURL;
     }
 
     if (startsWithStar && endsWithStar) {
-      return _currentURL.includes(_url.replace(/\*/g, ""));
+      return currentURL.includes(url.replace(/\*/g, ""));
     }
 
     if (startsWithStar) {
-      return _currentURL.endsWith(_url.replace(/\*/g, ""));
+      return currentURL.endsWith(url.replace(/\*/g, ""));
     }
 
     if (endsWithStar) {
-      return _currentURL.startsWith(_url.replace(/\*/g, ""));
+      return currentURL.startsWith(url.replace(/\*/g, ""));
     }
 
     return false;

--- a/assets/javascripts/discourse/services/dropdown-buttons.js
+++ b/assets/javascripts/discourse/services/dropdown-buttons.js
@@ -35,24 +35,28 @@ export default class DropdownButtonsService extends Service {
     // case 3 - url starts with *, e.g. *example, it should match any url ending with "example"
     // case 4 - url ends with *, e.g. example*, it should match any url starting with "example"
 
-    const startsWithStar = url.startsWith("*");
-    const endsWithStar = url.endsWith("*");
+    // Do all string comparisons in lowercase.
+    const _url = url.toLowerCase();
+    const _currentURL = this.router.currentURL.toLowerCase();
+
+    const startsWithStar = _url.startsWith("*");
+    const endsWithStar = _url.endsWith("*");
     const exactMatch = !startsWithStar && !endsWithStar;
 
     if (exactMatch) {
-      return url === this.router.currentURL;
+      return _url === _currentURL;
     }
 
     if (startsWithStar && endsWithStar) {
-      return this.router.currentURL.includes(url.replace(/\*/g, ""));
+      return _currentURL.includes(_url.replace(/\*/g, ""));
     }
 
     if (startsWithStar) {
-      return this.router.currentURL.endsWith(url.replace(/\*/g, ""));
+      return _currentURL.endsWith(_url.replace(/\*/g, ""));
     }
 
     if (endsWithStar) {
-      return this.router.currentURL.startsWith(url.replace(/\*/g, ""));
+      return _currentURL.startsWith(_url.replace(/\*/g, ""));
     }
 
     return false;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "prettier:check": "prettier --check \"{app,assets,config,db,lib,spec,test}/**/*.{js,gjs,es6,scss}\"",
+    "prettier:fix": "prettier --check --write \"{app,assets,config,db,lib,spec,test}/**/*.{js,gjs,es6,scss}\""
+  },
   "devDependencies": {
     "@discourse/lint-configs": "1.3.10",
     "ember-template-lint": "6.0.0",

--- a/spec/system/preset_topic_composer_spec.rb
+++ b/spec/system/preset_topic_composer_spec.rb
@@ -233,6 +233,15 @@ RSpec.describe "Preset Topic Composer | preset topic creation", type: :system do
       expect(button).to have_text("New Question2")
     end
 
+    it "should add is-selected class to the button when in matching url and ignores casing" do
+      tag = "#{tag1.name}".upcase
+      visit "/tag/#{tag}"
+      PageObjects::Components::PresetTopicDropdown.new.button.click
+
+      button = find(:css, ".is-selected")
+      expect(button).to have_text("New Question2")
+    end
+
     it "should add is-selected class to the button when in categoryId" do
       visit "/c/#{cat.slug}"
       PageObjects::Components::PresetTopicDropdown.new.button.click


### PR DESCRIPTION
When `force lowercase tags` setting is disabled, the tag URLs may be generated both in lowercase, or mixed-case (as the tag defined).

So, the URL pattern field should ignore the case differences whenever it is possible, to avoid usages like the one below:


<img width="337" alt="Screenshot 2024-09-27 at 1 41 31 PM" src="https://github.com/user-attachments/assets/d0d11239-0f81-440b-9821-d49c1e63219f">
