### PR TITLE
Display only matching composer presets as New Topic dropdown options

### DIFF
--- a/assets/javascripts/discourse/components/new-topic-dropdown.js
+++ b/assets/javascripts/discourse/components/new-topic-dropdown.js
@@ -1,5 +1,6 @@
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
+import { defaultHomepage } from "discourse/lib/utilities";
 import Composer from "discourse/models/composer";
 import DropdownSelectBoxComponent from "select-kit/components/dropdown-select-box";
 
@@ -8,6 +9,7 @@ export default DropdownSelectBoxComponent.extend({
   siteSettings: service(),
   historyStore: service(),
   dropdownButtons: service(),
+  router: service(),
 
   selectKitOptions: {
     icon: "plus",
@@ -20,6 +22,14 @@ export default DropdownSelectBoxComponent.extend({
 
   get content() {
     return this.dropdownButtons.buttons;
+  },
+
+  get showButton() {
+    if (this.siteSettings.hide_new_topic_button_on_default_page) {
+      const currentRoute = this.router.currentRoute;
+      return currentRoute.name === `discovery.${defaultHomepage()}` ? false : true;
+    }
+    return true;
   },
 
   actions: {

--- a/assets/javascripts/discourse/services/dropdown-buttons.js
+++ b/assets/javascripts/discourse/services/dropdown-buttons.js
@@ -4,6 +4,7 @@ import Service, { service } from "@ember/service";
 export default class DropdownButtonsService extends Service {
   @service router;
   @service site;
+  @service siteSettings;
 
   @tracked buttons;
 
@@ -13,7 +14,7 @@ export default class DropdownButtonsService extends Service {
   }
 
   refreshButtons() {
-    this.buttons = this.site.topic_preset_buttons
+    const buttons = this.site.topic_preset_buttons
       .map((b) => ({
         ...b,
         highlightUrls: b.highlightUrls || [],
@@ -29,6 +30,15 @@ export default class DropdownButtonsService extends Service {
         }
         return button;
       });
+
+    this.buttons = buttons;
+
+    if (this.siteSettings.hide_unmatched_composer_presets) {
+      const filteredButtons = buttons.filter((b) => b.classNames === "is-selected");
+      if (filteredButtons.length > 0) {
+        this.buttons = filteredButtons;
+      }
+    }
   }
 
   #shouldHighlightByURL(url) {

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -53,12 +53,3 @@ body.category[style*="--category-color"] .new-topic-dropdown .btn {
   text-align: left;
   color: var(--danger);
 }
-
-.new-topic-dropdown.select-kit .select-kit-collection {
-  display: flex;
-  flex-direction: column;
-
-  .select-kit-row.is-selected {
-    order: -1;
-  }
-}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,7 +1,9 @@
 en:
   site_settings:
-   button_types: "Launch the editor to define various `new topic` buttons"
-   discourse_preset_topic_composer_enabled: "Enable preset topic composer"
+    button_types: "Launch the editor to define various `new topic` buttons"
+    hide_new_topic_button_on_default_page: "Hide 'New Topic' button on default page. Uncheck to display the button on all pages."
+    hide_unmatched_composer_presets: "Hide the composer presets that are NOT highlighted as recommendation."
+    discourse_preset_topic_composer_enabled: "Enable preset topic composer"
 
   admin_js:
     admin:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,7 @@
 en:
   discourse_preset_topic_composer_enabled: "Enable preset topic composer"
+  hide_new_topic_button_on_default_page: "Hide 'New Topic' button on default page. Uncheck to display the button on all pages."
+  hide_unmatched_composer_presets: "Hide the composer presets that are NOT highlighted as recommendation."
   button_types: Launch the editor to define various "new topic" buttons
   dialog:
       error_message: "Please fill required fields"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,12 @@ discourse_preset_topic_composer:
   discourse_preset_topic_composer_enabled:
     default: false
     client: true
+  hide_new_topic_button_on_default_page:
+    default: false
+    client: true
+  hide_unmatched_composer_presets:
+    default: false
+    client: true
   button_types:
     client: true
     default: >-


### PR DESCRIPTION
We already reached to 18 composer presets on our site, and that makes selecting a New Topic button dropdown option harder for the users.

Even though, we inject the word “Recommended” for the options with `is-selected` class, seeing the long list is confusing and overwhelming for some users.

This PR adds a couple new settings:
 * `hide_unmatched_composer_presets`: Hide the composer presets that are NOT highlighted as recommendation.
* `hide_new_topic_button_on_default_page`: "Hide 'New Topic' button on default page. Uncheck to display the button on all pages.


However the `hide_new_topic_button_on_default_page` feature is not working yet, and need help to make it work.

If I add `showButton` to the `assets/javascripts/discourse/connectors/after-create-topic-button/new-topic-dropdown.hbs` template, it hides the button at all times, doesn't respect the setting's value.

```handlebars
{{#if (and currentUser (and showButton (not createTopicDisabled)))}}
  {{new-topic-dropdown category=category}}
{{/if}}
```