### PR TITLE
DEV: Fix composer title assertion for new composer actions

### DIFF
--- a/spec/system/preset_topic_composer_spec.rb
+++ b/spec/system/preset_topic_composer_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe "Preset Topic Composer | preset topic creation" do
       expect(preset_dropdown.button).to have_text("New Topic")
       preset_dropdown.select("New Question2")
 
-      composer_title = find(".action-title")
-      expect(composer_title).to have_text(I18n.t("js.topic.create_long"))
+      expect(composer).to be_opened
     end
 
     it "can fetch a tag group with a / in the name" do


### PR DESCRIPTION
Core [PR#41275](https://github.com/discourse/discourse/pull/41275) changed the default promote_upcoming_changes_on_status from "stable" to "beta", which auto-enables the beta-status enable_new_composer_actions upcoming change (including in CI). The composer's .action-title then renders composer_actions.create_topic.label ("Create topic") instead of topic.create_long ("Create a new topic"), breaking the hardcoded text assertion.

Assert the composer opened instead, which is independent of the flag.